### PR TITLE
add missing autoload

### DIFF
--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -48,7 +48,7 @@ function store-command-stats() {
   start_time=`date "+%s"`
 }
 
-
+autoload add-zsh-hook
 autoload -U tell-terminal
 autoload -U tell-iterm2
 autoload -U notify-if-background


### PR DESCRIPTION
When I ran

```
source notify.plugin.zsh
```

I got the error 

```
command not found: add-zsh-hook
```

So I added the autoload to include that function.
