### PR TITLE
Support background notify in tmux

### DIFF
--- a/notify-if-background
+++ b/notify-if-background
@@ -12,6 +12,8 @@
 #
 # Exits with status 2 if the terminal is frontmost or the tab is active.
 #
+# Exits with status 3 if the pane is active in tmux.
+#
 # Requirements:
 #
 # - terminal-notifier.app
@@ -54,6 +56,15 @@ else
     return 2
   fi
 fi
+
+if [ $TMUX ]; then
+  TMUX_ACTIVE_TTY=$(tmux list-windows -a -F '#{window_active} #{pane_tty}' | egrep '^1' | cut -f2 -d' ')
+
+  if [ $TTY = $TMUX_ACTIVE_TTY ]; then
+      return 3
+  fi
+fi
+
 
 #cat /dev/stdin | growlnotify "$@"
 # growlnotify "$@" < /dev/stdin


### PR DESCRIPTION
hi.

I used zsh-notify on tmux.
All commands notified by foreground zsh on tmux.
Because tty of zsh in tmux is not active-terminal tty.

I Added some code that check active tty in tmux.
If command finished tty is active tty in tmux, exit with 3.
