### PR TITLE
Use attention demand instead of focus stealing for terminal window by default (Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Also, the plugin assumes that both `terminal-notifier` and `growlnotify` are
 installed in `/usr/local/bin`. You can change these defaults by setting the
 `$SYS_NOTIFIER` or `$GROWL_NOTIFIER` environment variables.
 
+On Linux if you have wmctrl installed, then you can set the $ZSH_NOTIFY_FOCUS_TERMINAL
+enviroment variable to "true" to change focus to the terminal emulator window when a notification
+is posted. By default the terminal window will just demand attention.
+
 
 [growlnotify]: http://growl.info/extras.php/#growlnotify
 [terminal-notifier]: https://github.com/alloy/terminal-notifier 

--- a/notify-if-background
+++ b/notify-if-background
@@ -80,7 +80,12 @@ elif [[ -x "$GROWL_NOTIFIER" ]]; then
 elif [[ -x "$NOTIFY_NOTIFIER" ]]; then
   "$NOTIFY_NOTIFIER" "$title" "$message"
   if (( $+commands[wmctrl] )); then
-    wmctrl -ia $(wmctrl -lp | awk -vpid=$PPID_FIRST '$3==pid {print $1; exit}')
+    if [[ $ZSH_NOTIFY_FOCUS_TERMINAL == "true" ]]; then
+      wmctrl -ia $(wmctrl -lp | awk -vpid=$PPID_FIRST '$3==pid {print $1; exit}')
+    else
+      # xdotool set_window --urgency 1 $(xdotool search --onlyvisible --pid $PPID_FIRST 2>/dev/null | head -n 1)
+      wmctrl -i -r $(wmctrl -lp | awk -vpid=$PPID_FIRST '$3==pid {print $1; exit}') -b add,demands_attention
+    fi
   fi
 else
   echo "No notifier program found." > /dev/stderr

--- a/notify-if-background
+++ b/notify-if-background
@@ -83,7 +83,6 @@ elif [[ -x "$NOTIFY_NOTIFIER" ]]; then
     if [[ $ZSH_NOTIFY_FOCUS_TERMINAL == "true" ]]; then
       wmctrl -ia $(wmctrl -lp | awk -vpid=$PPID_FIRST '$3==pid {print $1; exit}')
     else
-      # xdotool set_window --urgency 1 $(xdotool search --onlyvisible --pid $PPID_FIRST 2>/dev/null | head -n 1)
       wmctrl -i -r $(wmctrl -lp | awk -vpid=$PPID_FIRST '$3==pid {print $1; exit}') -b add,demands_attention
     fi
   fi


### PR DESCRIPTION
When wmctrl is installed, the terminal window always steals focus, it is very distracting.
I think this feature should be only explicitly enabled. Instead by default we can use attention demand. This means that the window icon on the task bar will blink.