### PR TITLE
Fixes terminal-notifier options

### DIFF
--- a/notify-if-background
+++ b/notify-if-background
@@ -156,7 +156,7 @@
 
             zstyle -s ':notify:' "$type"-icon icon
 
-            echo "$message" | terminal-notifier "$app_id_option" -appIcon "$icon" -title "$notification_title" 1>/dev/null
+            echo "$message" | terminal-notifier ${=app_id_option} -appIcon "$icon" -title "$notification_title" 1>/dev/null
 
             if zstyle -t ':notify:' activate-terminal; then
                 echo tell app id \"$app_id\" to activate | osascript 1>/dev/null


### PR DESCRIPTION
This commit fixes terminal-notifier options.

## Before this commit
Do not focus the terminal when click the notification.

## After this commit
Focus the terminal when click the notification.

Thanks to great project.