### PR TITLE
Enable to play sound (on mac)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Use `zstyle` in your `~/.zshrc`.
     
     [Try this][dogefy.sh]. Wow.
 
+- Set a sound for error and success notifications, when usign the built-in notifier.
+  This feature currently works on Mac only.
+
+        zstyle ':notify:*' error-sound "Glass"
+        zstyle ':notify:*' success-sound "default"
+
 - Have the terminal come back to front when the notification is posted.
 
         zstyle ':notify:*' activate-terminal yes

--- a/notify-if-background
+++ b/notify-if-background
@@ -141,8 +141,10 @@
         zstyle -s ':notify:' "$type"-title notification_title \
             || notification_title="$titles[$type]"
 
+        zstyle -s ':notify:' "$type"-sound notification_sound
+
         function notifier-mac {
-            local app_id app_id_option
+            local app_id app_id_option sound_option
 
             if [[ "$TERM_PROGRAM" == 'iTerm.app' ]]; then
                 app_id="com.googlecode.iterm2"
@@ -154,9 +156,13 @@
                 app_id_option="-activate $app_id -sender $app_id"
             fi
 
+            if [[ ! -z "$notification_sound" ]]; then
+                sound_option="-sound $notification_sound"
+            fi
+
             zstyle -s ':notify:' "$type"-icon icon
 
-            echo "$message" | terminal-notifier ${=app_id_option} -appIcon "$icon" -title "$notification_title" 1>/dev/null
+            echo "$message" | terminal-notifier ${=app_id_option} ${=sound_option} -appIcon "$icon" -title "$notification_title" 1>/dev/null
 
             if zstyle -t ':notify:' activate-terminal; then
                 echo tell app id \"$app_id\" to activate | osascript 1>/dev/null


### PR DESCRIPTION
I want to receive notification with sound, so I create this PR.

This commit is enable to play sound for notification.
It currently works on mac only, because it is using terminal-notifier command line option.