### PR TITLE
Disable notification if DISPLAY is not set.

### DIFF
--- a/notify-if-background
+++ b/notify-if-background
@@ -28,7 +28,7 @@
             fi
         elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
             echo apple-terminal
-        elif which xdotool > /dev/null 2>&1; then
+        elif which xdotool > /dev/null 2>&1 && [[ "$DISPLAY" != '' ]]; then
             echo xdotool
         else
             return 1


### PR DESCRIPTION
I have ran into an issue with zsh-plugin enabled. When I log into my machine with ssh, then every time the command finishes I get annoying message 
```
Error: Can't open display: (null)
Failed creating new xdo instance
```
The fix is easy - don't show notification when the DISPLAY is not set.