### PR TITLE
Add option to disable urgency hint with wmctrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Use `zstyle` in your `~/.zshrc`.
 
         zstyle ':notify:*' activate-terminal yes
 
+- Disable setting the urgency hint for the terminal when the notification is posted (Linux only).
+
+        zstyle ':notify:*' disable-urgent yes
+
 - Set a different timeout for notifications for successful commands
   (notifications for failed commands are posted without accounting for
   the time it took to complete).

--- a/notify-if-background
+++ b/notify-if-background
@@ -199,7 +199,7 @@
 
                 if zstyle -t ':notify:' activate-terminal; then
                     wmctrl -ia $(wmctrl -lp | awk -vpid=$parent_pid '$3==pid {print $1; exit}')
-                else
+                elif ! (zstyle -t ':notify:' disable-urgent); then
                     wmctrl -i -r $(wmctrl -lp | awk -vpid=$parent_pid '$3==pid {print $1; exit}') -b add,demands_attention
                 fi
             fi


### PR DESCRIPTION
It doesn't work correctly for terminals running in daemon mode (like [urxvt](https://linux.die.net/man/1/urxvtd)).