### PR TITLE
Ignore xdotool error messages when no window is focused.

### DIFF
--- a/notify-if-background
+++ b/notify-if-background
@@ -95,7 +95,7 @@
             "xdotool")
                 local active_wid
 
-                active_wid=$(xdotool getactivewindow)
+                active_wid=$(xdotool getactivewindow 2> /dev/null)
 
                 if [[ "$active_wid" == "$WINDOWID" ]]; then
                     return 0


### PR DESCRIPTION
`xdotool getactivewindow` prints an error message when no window is focused:

```
XGetWindowProperty[_NET_ACTIVE_WINDOW] failed (code=1)
xdo_get_active_window reported an error
```

This message appears above the prompt and is a bit annoying. I think it should be ignored. Of course this would also mean that actual xdotool errors are ignored, but those are much less common than the other cases.