### PR TITLE
remove stdin forced redirect

### DIFF
--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -10,7 +10,7 @@ zstyle ':notify:*' parent-pid $PPID
 # Notify an error with no regard to the time elapsed (but always only
 # when the terminal is in background).
 function notify-error {
-    notify-if-background error < /dev/stdin &!
+    notify-if-background error
 }
 
 # Notify of successful command termination, but only if it took at least


### PR DESCRIPTION
The reason I created this pr is that I'm getting this weird error when C-c(ing) into my terminal:

```notify-error:1: permission denied: /dev/stdin```


In my understanding shell functions repass its current stdin into the command if you don't specify them. And by not forcing It works and don't throw errors.