### PR TITLE
Fix tests on linux:

### DIFF
--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -51,7 +51,7 @@ function _zsh-notify-should-notify() {
         return 1
     fi
     local enable_on_ssh
-    zstyle -b ':notify:*' enable-on-ssh enable_on_ssh
+    zstyle -b ':notify:*' enable-on-ssh enable_on_ssh || true
     if _zsh-notify-is-ssh && [[ $enable_on_ssh == 'no' ]]; then
         return 2
     fi

--- a/tests/xdotool.zunit
+++ b/tests/xdotool.zunit
@@ -2,6 +2,7 @@
 
 @setup {
   load ../notify.plugin.zsh
+  zstyle ':notify:*' always-check-active-window 'yes'
 
   if ! command -v xdotool 1>/dev/null 2>/dev/null; then
     skip 'must be run on x11'
@@ -20,12 +21,17 @@
   assert $state equals 0
 }
 
-@test 'xterm: is-terminal-active - window minimized' {
+@test 'xterm: is-terminal-active - window unmapped' {
   store-window-id
 
-  xdotool windowminimize "$(xdotool getwindowfocus)"
-  sleep 1
-
+  # On tiling window managers, windowminize won't work, so we unmap and remap
+  # the window.
+  local focused_wid 
+  focused_wid="$(xdotool getwindowfocus)"
+  xdotool windowunmap --sync "$focused_wid"
   run is-terminal-active
-  assert $state equals 1
+  local is_active=$state
+  xdotool windowmap --sync "$focused_wid"
+
+  assert $is_active equals 1
 }

--- a/xdotool/functions
+++ b/xdotool/functions
@@ -116,7 +116,7 @@ function zsh-notify() {
 # incorrect.
 function store-window-id() {
     local always_check
-    zstyle -b ':notify:' always-check-active-window always_check
+    zstyle -b ':notify:' always-check-active-window always_check || true
 
     # some linux terminals such as gnome-terminal don't set the WINDOWID, so we
     # check if it's empty. If it's empty or the user explicitly requests it (see


### PR DESCRIPTION
- `zstyle -b` apparently returns false if the boolean value is false, so
  we need to append `|| true` to it.
- use windowunmap instead of windowminimize, which should work tiling
  window managers
- get rid of `sleep` and use `--sync` arg to verify xdotool finished