### PR TITLE
Redirecting foreground-detection error message to stderr

### DIFF
--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -9,7 +9,7 @@ elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then
     source "$plugin_dir"/xdotool/functions
 else
-    echo "zsh-notify: unsupported environment" >&1
+    echo "zsh-notify: unsupported environment" >&2
     return
 fi
 
@@ -96,7 +96,7 @@ function zsh-notify-after-command() {
 
     local error_log notifier now time_elapsed
 
-    zstyle -s ':notify:' error-log error_log 
+    zstyle -s ':notify:' error-log error_log
     zstyle -s ':notify:' notifier notifier
 
     touch "$error_log"


### PR DESCRIPTION
Hello. I wanted to ask this first, but I was not able to create an issue, so I ventured forward, straight to a pull request :smiley: 

I'm not sure if you meant it, but here

https://github.com/marzocchi/zsh-notify/blob/master/notify.plugin.zsh#L12

You explicitly redirect an error message to stdout. Not only it looks weird and redundant, but it breaks one of my dotfiles :stuck_out_tongue: 