### PR TITLE
Use xdsotool getwindowfocus

### DIFF
--- a/xdotool/functions
+++ b/xdotool/functions
@@ -12,7 +12,7 @@ is-terminal-active() {
     function is-terminal-window-active {
         local active_wid wid
 
-        active_wid=$(xdotool getactivewindow)
+        active_wid=$(xdotool getwindowfocus)
 
         zstyle -s ':notify:' window-id wid
 


### PR DESCRIPTION
`xdsotool getactivewindow` returns an error if no window is currently active:
```
XGetWindowProperty[_NET_ACTIVE_WINDOW] failed (code=1)
xdo_get_active_window reported an error
```

The docs mention that it getactivewindow "is often more reliable than getwindowfocus", but I have had no problems with getwindowfocus.

Alternatively, find another way of suppressing the error and treating it like the terminal has lost focus?