### PR TITLE
Use lib-notify without xdotools if activate-window is false and notify-send is available

### DIFF
--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -2,13 +2,15 @@
 
 plugin_dir="$(dirname $0:A)"
 
+zstyle -b ':notify:*' activate-terminal activate_terminal_enabled
+
 if [[ "$TERM_PROGRAM" == 'iTerm.app' ]]; then
     source "$plugin_dir"/applescript/functions
 elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
     source "$plugin_dir"/applescript/functions
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then
     source "$plugin_dir"/xdotool/functions
-elif command -v notify-send > /dev/null 2>&1 && (!zstyle -t ':notify:' activate-terminal); then
+elif command -v notify-send > /dev/null 2>&1 && (!activate_terminal_enabled); then
     source "$plugin_dir"/xdotool/functions
 else
     echo "zsh-notify: unsupported environment" >&2

--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -8,6 +8,8 @@ elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
     source "$plugin_dir"/applescript/functions
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then
     source "$plugin_dir"/xdotool/functions
+elif command -v notify-send > /dev/null 2>&1 && (!zstyle -t ':notify:' activate-terminal); then
+    source "$plugin_dir"/xdotool/functions
 else
     echo "zsh-notify: unsupported environment" >&2
     return


### PR DESCRIPTION
If xdotools is not available but notify-send is we can still send notifications as long as activate-window option is disabled.

This is for example the case for wsl configurations where lib-notify's `notify-send` can be mocked using poweshell and toast. xdotools is obviously not available in this scenario. 

This PR adds a branch if the above is true and uses the xdotools (or linux) module.