### PR TITLE
Fix "Invalid number of options" error when command starts with a space

### DIFF
--- a/xdotool/functions
+++ b/xdotool/functions
@@ -69,7 +69,7 @@ function zsh-notify() {
             message="${message#* }"
     fi
 
-    notify-send -a ${=app_name} -t $expire_time ${=icon_option} "$title" -- "$message"
+    notify-send -a "${=app_name}" -t $expire_time ${=icon_option} "$title" -- "$message"
 
     function play-sound {
         if command -v paplay > /dev/null 2>&1; then


### PR DESCRIPTION
To prevent saving command to history, user may use a space before command. For notify-send this results in an error.
To properly fix this, more sophisticated app name detection (line 68) required.