### PR TITLE
Fixed that "unsupported environment" is displayed on tmux.

### DIFF
--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -4,6 +4,8 @@ plugin_dir="$(dirname $0:A)"
 
 if [[ "$TERM_PROGRAM" == 'iTerm.app' ]]; then
     source "$plugin_dir"/applescript/functions
+elif [[ "$TERM_PROGRAM" == 'tmux' && "$LC_TERMINAL" == 'iTerm2' ]]; then
+    source "$plugin_dir"/applescript/functions
 elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
     source "$plugin_dir"/applescript/functions
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then


### PR DESCRIPTION
When using tmux, the environment variable $TERM_PROGRAM is overwritten with the value 'tmux',
and "unsupported environment" will be displayed.
As a workaround, use the $LC_TERMINAL.