### PR TITLE
Fix "unsupported environment" fail on tmux 3.2 for iTerm2 and Apple Terminal

### DIFF
--- a/applescript/functions
+++ b/applescript/functions
@@ -26,9 +26,9 @@ function is-terminal-active() {
     function is-terminal-window-active {
         local term
 
-        if [[ "$TERM_PROGRAM" == 'iTerm.app' ]]; then
+        if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ -n "$ITERM_SESSION_ID" ]]; then
             term=iterm2
-        elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
+        elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$TERM_SESSION_ID" ]]; then
             term=apple-terminal
         else
             return 2
@@ -72,9 +72,9 @@ function zsh-notify() {
 
     title=$(notification-title "$type" time_elapsed "$time_elapsed")
 
-    if [[ "$TERM_PROGRAM" == 'iTerm.app' ]]; then
+    if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ -n "$ITERM_SESSION_ID" ]]; then
         app_id="com.googlecode.iterm2"
-    elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
+    elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$TERM_SESSION_ID" ]]; then
         app_id="com.apple.terminal"
     fi
 

--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -2,9 +2,7 @@
 
 plugin_dir="$(dirname $0:A)"
 
-if [[ "$TERM_PROGRAM" == 'iTerm.app' ]]; then
-    source "$plugin_dir"/applescript/functions
-elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
+if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$ITERM_SESSION_ID" ]] || [[ -n "$TERM_SESSION_ID" ]]; then
     source "$plugin_dir"/applescript/functions
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then
     source "$plugin_dir"/xdotool/functions

--- a/tests/iterm2.zunit
+++ b/tests/iterm2.zunit
@@ -3,20 +3,20 @@
 @setup {
   load ../notify.plugin.zsh
 
-  if [[ "$TERM_PROGRAM" != "iTerm.app" ]]; then
+  if [[ "$TERM_PROGRAM" != "iTerm.app" ]] && [[ -z "$ITERM_SESSION_ID" ]]; then
     skip 'this test must be run in iTerm.app'
   fi
 }
 
 @teardown {
-  if [[ "$TERM_PROGRAM" != "iTerm.app" ]]; then
+  if [[ "$TERM_PROGRAM" != "iTerm.app" ]] && [[ -z "$ITERM_SESSION_ID" ]]; then
     return
   fi
 
   osascript <<SCPT
 tell app id "com.googlecode.iterm2"
   activate
-end 
+end
 SCPT
 }
 
@@ -24,7 +24,7 @@ SCPT
   osascript <<SCPT
 tell app id "com.googlecode.iterm2"
   activate
-end 
+end
 SCPT
 
   run is-terminal-active

--- a/tests/zsh-notify.zunit
+++ b/tests/zsh-notify.zunit
@@ -35,7 +35,7 @@
 
 
 @test 'zsh-notify - terminal-notifier in iTerm2' {
-  if [[ "$TERM_PROGRAM" != "iTerm.app" ]]; then
+  if [[ "$TERM_PROGRAM" != "iTerm.app" ]] && [[ -z "$ITERM_SESSION_ID" ]]; then
     skip 'must be run in iTerm2'
   fi
 
@@ -52,7 +52,7 @@
 }
 
 @test 'zsh-notify - terminal-notifier in iTerm2 with icon' {
-  if [[ "$TERM_PROGRAM" != "iTerm.app" ]]; then
+  if [[ "$TERM_PROGRAM" != "iTerm.app" ]] && [[ -z "$ITERM_SESSION_ID" ]]; then
     skip 'must be run in iTerm2'
   fi
 


### PR DESCRIPTION
tmux 3.2 has started to set `TERM_PROGRAM` to `tmux`. See [changes from 3.1c to 3.2](https://github.com/tmux/tmux/blob/master/CHANGES)

This causes zsh-notify to stop working on macOS because it assumes `TERM_PROGRAM` to be set to `iTerm2.app` or `Apple_Terminal`.

For me, zsh-notify fails silently, but I think that depends on how you load zsh-notify. You may get the error message `zsh-notify: unsupported environment`

So, we should make zsh-notify smarter in how it detects iTerm2.
Unfortunately, it isn't completely trivial to do that.
The official way to detect iTerm is apparently this rather long script https://iterm2.com/utilities/it2check

In this PR I suggest a simplistic method of checking `ITERM_SESSION_ID`. That seems to be set even inside tmux, as long as the tmux session was started from iTerm2.

`TERM_SESSION_ID` works similarly for Apple Terminal.

The changes should be backward compatible and still work in tmux versions before 3.2.

I don't have an arsenal of machines to test this on. So, if people report where it fails, we can improve it. If we really need to, we could copy/paste the content of [it2check](https://iterm2.com/utilities/it2check), but that feels heavy-handed.

EDIT: I eventually noticed the PR https://github.com/marzocchi/zsh-notify/pull/83, which is fixing the same thing, but I think mine is a bit more thorough.
