### PR TITLE
Add support for JetBrains IDE built-in terminal

### DIFF
--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -4,6 +4,8 @@ plugin_dir="$(dirname $0:A)"
 
 if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$ITERM_SESSION_ID" ]] || [[ -n "$TERM_SESSION_ID" ]]; then
     source "$plugin_dir"/applescript/functions
+elif [[ "$TERMINAL_EMULATOR" == 'JetBrains-JediTerm' ]]; then
+    source "$plugin_dir"/applescript/functions
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then
     source "$plugin_dir"/xdotool/functions
 else


### PR DESCRIPTION
Hello, great plugin!

I noticed it didn't initialise in JetBrains' (eg. IntelliJ IDEA) built-in terminal and found a quick-fix for it, so I thought I'd share