### PR TITLE
Add check for active hotkey window in iTerm2

### DIFF
--- a/applescript/resources/is-iterm2-active.applescript
+++ b/applescript/resources/is-iterm2-active.applescript
@@ -9,11 +9,20 @@ on run ttyName
 
     if ttyName is equal to "" then error "Usage: is-iterm2-active.applescript TTY"
 
-    tell application "System Events"
-        tell item 1 of (application processes whose bundle identifier is "com.googlecode.iterm2")
-            if frontmost is not true then error "iTerm is not the frontmost application"
+    tell application id "com.googlecode.iterm2"
+        tell current window
+            set isHotkeyWindow to is hotkey window
+            if isHotkeyWindow and visible is not true then error "iTerm is not the frontmost application"
         end tell
     end tell
+
+    if isHotkeyWindow is not true then
+        tell application "System Events"
+            tell item 1 of (application processes whose bundle identifier is "com.googlecode.iterm2")
+                if frontmost is not true then error "iTerm is not the frontmost application"
+            end tell
+        end tell
+    end if
 
     tell application id "com.googlecode.iterm2"
         set currentTty to tty of (current session of current tab of current window) as text


### PR DESCRIPTION
Old way of checking if terminal window is active didn't work for hotkey
window with `Floating window` option active. Used iTerm scripting API
to use different checks, if last used window is the hotkey window.