### PR TITLE
Check focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ sourcing `notify.plugin.zsh`.
 
         zstyle ':notify:*' always-check-active-window yes
 
+- Ignore checking if the terminal is focused at all:
+
+        zstyle ':notify:*' check-focus no
+
 [terminal-notifier]: https://github.com/alloy/terminal-notifier 
 [libnotify]: https://github.com/GNOME/libnotify
 [iterm2]: http://www.iterm2.com/

--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -27,6 +27,7 @@ zstyle ':notify:*' error-icon ''
 zstyle ':notify:*' disable-urgent no
 zstyle ':notify:*' activate-terminal no
 zstyle ':notify:*' always-check-active-window no
+zstyle ':notify:*' check-focus yes
 zstyle ':notify:*' blacklist-regex ''
 zstyle ':notify:*' enable-on-ssh no
 zstyle ':notify:*' always-notify-on-failure yes
@@ -78,7 +79,9 @@ function _zsh-notify-should-notify() {
     fi
     # this is the last check since it will be the slowest if
     # `always-check-active-window` is set.
-    if is-terminal-active; then
+    local check_focus
+    zstyle -b ':notify:*' check-focus check_focus
+    if [[ $check_focus != no ]] && is-terminal-active; then
         return 4
     fi
     return 0

--- a/xdotool/functions
+++ b/xdotool/functions
@@ -137,5 +137,7 @@ function store-window-id() {
     fi
 }
 
-autoload -U add-zsh-hook
-add-zsh-hook preexec store-window-id
+if zstyle -t ':notify:' check-focus; then
+    autoload -U add-zsh-hook
+    add-zsh-hook preexec store-window-id
+fi


### PR DESCRIPTION
This add support for disabling check on focus.

This is useful, at least for me: the fact that the window has focus does not imply at all that I am looking at it. I could be AFK.

Also, this allows Wayland users to use this plugin (of course with not as many functionalities as they could on X, but still)