### PR TITLE
Fix focus checking on Linux

### DIFF
--- a/xdotool/functions
+++ b/xdotool/functions
@@ -121,6 +121,10 @@ function zsh-notify() {
 # existing shells in the previous window, but in all other cases it will be
 # incorrect.
 function store-window-id() {
+    if ! (zstyle -t ':notify:' check-focus); then
+        return
+    fi
+
     local always_check
     zstyle -b ':notify:' always-check-active-window always_check || true
 
@@ -137,7 +141,5 @@ function store-window-id() {
     fi
 }
 
-if zstyle -t ':notify:' check-focus; then
-    autoload -U add-zsh-hook
-    add-zsh-hook preexec store-window-id
-fi
+autoload -U add-zsh-hook
+add-zsh-hook preexec store-window-id


### PR DESCRIPTION
Currently focus checking on linux has the following problems:
1. It ignores the default value of zstyle setting, because its value is [checked](https://github.com/marzocchi/zsh-notify/blob/9517abdbac9977700a24aa22d8ccc830b985d125/xdotool/functions#L140) before it is set [here](https://github.com/marzocchi/zsh-notify/blob/9517abdbac9977700a24aa22d8ccc830b985d125/notify.plugin.zsh#L30).
2. It does not allow you to set zstyle setting after the plugin is already loaded, because it only checks for it during the loading (while the rest of the settings _must_ be set after that).

This PR fixes the problems described above.