### PR TITLE
Add more requirements to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _When using `tmux` on Yosemite:_
 
 #### Linux/Other
 
-Install `notify-send` (default*) -- available in [libnotify][libnotify]
+Install `notify-send` (default*) -- available in [libnotify][libnotify], `xdotool` and `wmctrl`
 
 ---
 


### PR DESCRIPTION
The linux part of the requirements was missing xdotool and wmctrl. The absence of the latter resulted on my machine in an error message 'unknown environment'.
Adding those two to the requirements should make the onboarding smoother.