### PR TITLE
Play notification sound in background on Linux

### DIFF
--- a/xdotool/functions
+++ b/xdotool/functions
@@ -73,11 +73,11 @@ function zsh-notify() {
 
     function play-sound {
         if command -v paplay > /dev/null 2>&1; then
-            paplay "$1"
+            paplay "$1" &> /dev/null &
         elif command -v aplay > /dev/null 2>&1; then
-            aplay "$1"
+            aplay "$1" &> /dev/null &
         elif command -v ossplay > /dev/null 2>&1; then
-            ossplay "$1"
+            ossplay "$1" &> /dev/null &
         else
             echo "could not find a sound file player." >&2
             return 1


### PR DESCRIPTION
This pull request allows the notification sound to play in the background. With this change, you can start typing the next command without waiting for the sound to finish playing.

The code for playing the sound has been updated to include the &> /dev/null & redirection, which runs the command in the background and discards both standard output and standard error.