### PR TITLE
Make MacOS detection terminal agnostic

### DIFF
--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -2,7 +2,7 @@
 
 plugin_dir="$(dirname $0:A)"
 
-if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$ITERM_SESSION_ID" ]] || [[ -n "$TERM_SESSION_ID" ]]; then
+if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$ITERM_SESSION_ID" ]] || [[ -n "$TERM_SESSION_ID" ]] || [[ "$(uname)" == "Darwin" ]]; then
     source "$plugin_dir"/applescript/functions
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then
     source "$plugin_dir"/xdotool/functions


### PR DESCRIPTION
With the current configuration `zsh-notify` doesn't work on Mac when using Alacritty (and probably any other terminal program). We can do a kernel check instead for Darwin.