### PR TITLE
Add WezTerm support

### DIFF
--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -2,7 +2,9 @@
 
 plugin_dir="$(dirname $0:A)"
 
-if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$ITERM_SESSION_ID" ]] || [[ -n "$TERM_SESSION_ID" ]]; then
+if [[ "$TERM_PROGRAM" == 'WezTerm' ]]; then
+    source "$plugin_dir"/wezterm/functions
+elif [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$ITERM_SESSION_ID" ]] || [[ -n "$TERM_SESSION_ID" ]]; then
     source "$plugin_dir"/applescript/functions
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then
     source "$plugin_dir"/xdotool/functions

--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -17,7 +17,6 @@ zstyle ':notify:*' error-log /dev/stderr
 zstyle ':notify:*' notifier zsh-notify
 zstyle ':notify:*' expire-time 0
 zstyle ':notify:*' app-name ''
-zstyle ':notify:*' notifier zsh-notify
 zstyle ':notify:*' success-title '#win (in #{time_elapsed})'
 zstyle ':notify:*' success-sound ''
 zstyle ':notify:*' success-icon ''

--- a/wezterm/functions
+++ b/wezterm/functions
@@ -1,0 +1,52 @@
+# vim: set nowrap filetype=zsh:
+#
+# is-terminal-active always exits with status 1 since the WezTerm script itself
+# handles this detection.
+function is-terminal-active() {
+    # FIXME: re-add tmux support
+    return 1
+}
+
+function zsh-notify() {
+    local message title time_elapsed type check_focus
+
+    if [[ $# -lt 2 ]]; then
+        echo usage: zsh-notify TYPE TIME_ELAPSED 1>&2
+        return 1
+    fi
+
+    zstyle -s ':notify:' plugin-dir plugin_dir
+    source "$plugin_dir"/lib
+
+    type="$1"
+    time_elapsed="$(format-time $2)"
+    message=$(<&0)
+
+    # sound and icon not supported by WezTerm
+
+    title=$(notification-title "$type" time_elapsed "$time_elapsed")
+
+    check_focus='false'
+    zstyle -t ':notify:*' check-focus \
+      && check_focus='true'
+
+    zstyle -s ':notify:' expire-time expire_time
+
+    __wezterm_set_user_var NOTIFICATION "$(jq \
+      -nc \
+      --arg title "$title" \
+      --arg message "$message" \
+      --argjson check_focus "$check_focus" \
+      --argjson timeout_milliseconds "$expire_time" \
+      '{
+        title: $title,
+        message: $message,
+        check_focus: $check_focus,
+        timeout_milliseconds: $timeout_milliseconds
+      }' \
+    )"
+
+    if zstyle -t ':notify:' activate-terminal; then
+        wezterm cli activate-pane
+    fi
+}


### PR DESCRIPTION
Depends on installing [`jq`](https://github.com/jqlang/jq), activating WezTerm's [shell integration](https://wezfurlong.org/wezterm/shell-integration.html?h=integration#user-vars) (for the `__wezterm_set_user_var()` shell function), and placing following snippet in WezTerm's [.wezterm.lua](https://wezfurlong.org/wezterm/config/files.html#quick-start):
```lua
local wezterm = require 'wezterm'
local config = {}

wezterm.on('user-var-changed', function(window, pane, name, value)
  if name ~= "NOTIFICATION" then
    return
  end

  local notification = wezterm.json_parse(value)

  if notification.check_focus
    and window:is_focused()
    and window:active_pane():pane_id() == pane:pane_id()
  then
    return
  end

  if not notification.timeout_milliseconds then
    notification.timeout_milliseconds = nil
  end

  window:toast_notification(notification.title, notification.message,
    nil, notification.timeout_milliseconds)
end)

return config
```