### PR TITLE
Add support for any macOS terminal

### DIFF
--- a/applescript/functions
+++ b/applescript/functions
@@ -1,5 +1,22 @@
 # vim: set nowrap filetype=zsh:
-#
+
+# run an AppleScript, selected from ./resources by basename given as the
+# first argument, with all other arguments are positional arguments to the
+# script's `on run` handler.
+function run-applescript() {
+    local plugin_dir
+
+    zstyle -s ':notify:' plugin-dir plugin_dir
+    source "$plugin_dir"/lib
+
+    local script_name
+
+    script_name="$1"
+    shift
+
+    "$plugin_dir"/applescript/resources/"$script_name".applescript $@ 2>/dev/null
+}
+
 # is-terminal-active exits with status 0 when the current shell is running on an
 # active terminal window or tab, status 1 when the window or tab is in background
 # and status 2 if the current terminal is not supported (eg. it's not iTerm2 nor
@@ -10,31 +27,22 @@ function is-terminal-active() {
     zstyle -s ':notify:' plugin-dir plugin_dir
     source "$plugin_dir"/lib
 
-    # run an AppleScript, selected from ./resources by basename given as the
-    # first argument, with all other arguments are positional arguments to the
-    # script's `on run` handler.
-    function run-applescript() {
-        local script_name
-
-        script_name="$1"
-        shift
-
-        "$plugin_dir"/applescript/resources/"$script_name".applescript $@ 2>/dev/null
-    }
-
     # exit with code 0 if the terminal window/tab is active, code 1 if inactive.
     function is-terminal-window-active {
-        local term
+        local script_name script_arg
 
         if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ -n "$ITERM_SESSION_ID" ]]; then
-            term=iterm2
+            script_name=is-iterm2-active
+            script_arg=$(current-tty)
         elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$TERM_SESSION_ID" ]]; then
-            term=apple-terminal
+            script_name=is-apple-terminal-active
+            script_arg=$(current-tty)
         else
-            return 2
+            script_name=is-window-active-by-pid
+            script_arg=$(top-level-ppid)
         fi
 
-        run-applescript is-"$term"-active "$(current-tty)"
+        run-applescript $script_name $script_arg
     }
 
     if is-terminal-window-active; then
@@ -42,8 +50,8 @@ function is-terminal-active() {
             is-current-tmux-pane-active
             return $?
         fi
-      else
-          return $?
+        else
+            return $?
     fi
 }
 
@@ -72,11 +80,7 @@ function zsh-notify() {
 
     title=$(notification-title "$type" time_elapsed "$time_elapsed")
 
-    if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ -n "$ITERM_SESSION_ID" ]]; then
-        app_id="com.googlecode.iterm2"
-    elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$TERM_SESSION_ID" ]]; then
-        app_id="com.apple.terminal"
-    fi
+    app_id=$(run-applescript get-app-id-by-pid $(top-level-ppid))
 
     if [[ -n "$app_id" ]]; then
         app_id_option="-activate $app_id"

--- a/applescript/functions
+++ b/applescript/functions
@@ -50,8 +50,8 @@ function is-terminal-active() {
             is-current-tmux-pane-active
             return $?
         fi
-        else
-            return $?
+    else
+        return $?
     fi
 }
 

--- a/applescript/resources/get-app-id-by-pid.applescript
+++ b/applescript/resources/get-app-id-by-pid.applescript
@@ -1,0 +1,10 @@
+#!/usr/bin/osascript
+
+on run argv
+    set targetPID to item 1 of argv
+
+    tell application "System Events"
+        return bundle identifier of first process whose unix id is targetPID
+    end tell
+end run
+

--- a/applescript/resources/is-apple-terminal-active.applescript
+++ b/applescript/resources/is-apple-terminal-active.applescript
@@ -1,24 +1,24 @@
 #!/usr/bin/osascript -ss
 
 on run ttyName
-	try
-		set ttyName to first item of ttyName
-	on error
-		set ttyName to ""
-	end try
-	
-	if ttyName is equal to "" then error "Usage: is-apple-terminal-active.applescript TTY"
-	
-	tell application id "com.apple.terminal"
-		if frontmost is not true then error "Apple Terminal is not the frontmost application"
-	
-		-- fun stuff, with 2 tabs in one window AS reports 2 windows with one
-		-- tab each, and all the tabs are frontmost!
-		repeat with t in tabs of (windows whose frontmost is true)
-			if t's tty is equal to ttyName then return
-		end repeat
-		
-		error "Cannot find an active tab for '" & ttyName & "'"
-		
-	end tell
+    try
+        set ttyName to first item of ttyName
+    on error
+        set ttyName to ""
+    end try
+    
+    if ttyName is equal to "" then error "Usage: is-apple-terminal-active.applescript TTY"
+    
+    tell application id "com.apple.terminal"
+        if frontmost is not true then error "Apple Terminal is not the frontmost application"
+    
+        -- fun stuff, with 2 tabs in one window AS reports 2 windows with one
+        -- tab each, and all the tabs are frontmost!
+        repeat with t in tabs of (windows whose frontmost is true)
+            if t's tty is equal to ttyName then return
+        end repeat
+        
+        error "Cannot find an active tab for '" & ttyName & "'"
+        
+    end tell
 end run

--- a/applescript/resources/is-window-active-by-pid.applescript
+++ b/applescript/resources/is-window-active-by-pid.applescript
@@ -1,0 +1,14 @@
+#!/usr/bin/osascript -ss
+
+on run argv
+    set targetPID to item 1 of argv
+
+    tell application "System Events"
+        set appProcess to first process whose unix id is targetPID
+    end tell
+
+    tell application (name of appProcess)
+        if frontmost is not true then error "Window with pid " & targetPID & " is not the frontmost application"
+    end tell
+end run
+

--- a/lib
+++ b/lib
@@ -35,7 +35,7 @@ function top-level-ppid {
     # We're assuming the root process PID is equal to 1
     while [[ $ppid -ne 1 ]]; do
         pid=$ppid
-        ppid=$(ppid-of $pid)
+        ppid=$(ppid-of $pid) || return
     done
     
     echo $pid

--- a/lib
+++ b/lib
@@ -16,6 +16,31 @@ function current-tty {
     fi
 }
 
+# Find the top level parent PID of current shell (not including root process), also accounting for TMUX
+function top-level-ppid {
+    # Find parent PID of process by its PID
+    function ppid-of {
+        pid=$1
+        ps -p $pid -o ppid=
+    }
+
+    pid=$$
+
+    if is-inside-tmux; then
+        pid=$(tmux display-message -p '#{client_pid}')
+    fi
+
+    ppid=$(ppid-of $pid)
+
+    # We're assuming the root process PID is equal to 1
+    while [[ $ppid -ne 1 ]]; do
+        pid=$ppid
+        ppid=$(ppid-of $pid)
+    done
+    
+    echo $pid
+}
+
 # Exit with 0 if given TMUX pane is the active one.
 function is-current-tmux-pane-active {
     is-inside-tmux || return 1
@@ -40,11 +65,11 @@ function notification-title {
     zstyle -s ':notify:' "$type"-title title 
 
     while [[ $# -gt 0 ]]; do
-      k="$1"
-      v="$2"
-      title=$(echo $title | sed "s/#{$k}/$v/")
-      shift
-      shift
+        k="$1"
+        v="$2"
+        title=$(echo $title | sed "s/#{$k}/$v/")
+        shift
+        shift
     done
 
     echo $title

--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -2,7 +2,7 @@
 
 plugin_dir="$(dirname $0:A)"
 
-if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$ITERM_SESSION_ID" ]] || [[ -n "$TERM_SESSION_ID" ]]; then
+if command -v osascript >/dev/null 2>&1; then
     source "$plugin_dir"/applescript/functions
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then
     source "$plugin_dir"/xdotool/functions

--- a/tests/apple-terminal.zunit
+++ b/tests/apple-terminal.zunit
@@ -14,7 +14,7 @@
   fi
 
   osascript <<SCPT
-tell app id "com.apple.terminal"
+tell app id "com.apple.Terminal"
   activate
 end 
 SCPT
@@ -22,7 +22,7 @@ SCPT
 
 @test 'Apple Terminal: is-terminal-active - yes' {
   osascript <<SCPT
-tell app id "com.apple.terminal"
+tell app id "com.apple.Terminal"
   activate
 end 
 SCPT
@@ -34,7 +34,7 @@ SCPT
 @test 'Apple Terminal: is-terminal-active - app in background' {
   osascript <<SCPT
 tell app "System Events"
-    tell item 1 of (application processes whose bundle identifier is "com.apple.terminal")
+    tell item 1 of (application processes whose bundle identifier is "com.apple.Terminal")
       set visible to false
     end tell
 end tell
@@ -47,7 +47,7 @@ SCPT
 @test 'Apple Terminal: is-terminal-active - other tab active' {
   osascript <<SCPT
 tell app "System Events"
-    tell item 1 of (application processes whose bundle identifier is "com.apple.terminal")
+    tell item 1 of (application processes whose bundle identifier is "com.apple.Terminal")
       set frontmost to true
     end tell
 

--- a/tests/iterm2.zunit
+++ b/tests/iterm2.zunit
@@ -47,9 +47,9 @@ SCPT
 @test 'iTerm2: is-terminal-active - other tab active' {
   osascript <<SCPT
 tell app id "com.googlecode.iterm2"
-	tell current window
+    tell current window
     create tab with default profile
-	end tell
+    end tell
 end tell
 SCPT
 

--- a/tests/macos-terminals.zunit
+++ b/tests/macos-terminals.zunit
@@ -1,0 +1,51 @@
+#!/usr/bin/env zunit
+
+@setup {
+  load ../notify.plugin.zsh
+
+  if ! command -v osascript 1>/dev/null 2>/dev/null || [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] \
+    || [[ "$TERM_PROGRAM" == "iTerm.app" ]] || [[ -n "$ITERM_SESSION_ID" ]];
+  then
+    skip 'this test must be run in macOS terminal that is not iTerm2 or Apple Terminal (e.g. Alacritty)'
+  fi
+
+  app_id=$(osascript -e 'tell application "System Events" to return bundle identifier of first process where it is frontmost')
+}
+
+@teardown {
+  if ! command -v osascript 1>/dev/null 2>/dev/null || [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] \
+    || [[ "$TERM_PROGRAM" == "iTerm.app" ]] || [[ -n "$ITERM_SESSION_ID" ]];
+  then
+    return
+  fi
+
+  osascript <<SCPT
+tell app id "$app_id"
+  activate
+end 
+SCPT
+}
+
+@test 'Any other macOS terminal: is-terminal-active - yes' {
+  osascript <<SCPT
+tell app id "$app_id"
+  activate
+end 
+SCPT
+
+  run is-terminal-active
+  assert $state equals 0
+}
+
+@test 'Any other macOS terminal: is-terminal-active - app in background' {
+  osascript <<SCPT
+tell app "System Events"
+    tell item 1 of (application processes whose bundle identifier is "$app_id")
+      set visible to false
+    end tell
+end tell
+SCPT
+
+  run is-terminal-active
+  assert $state equals 1
+}

--- a/tests/zsh-notify.zunit
+++ b/tests/zsh-notify.zunit
@@ -16,7 +16,7 @@
 
   run zsh-notify success 3  <<<"notification text"
   assert $state equals 0
-  assert "$(get-args)" same_as "-activate com.apple.terminal -title #win (in 3s)"
+  assert "$(get-args)" same_as "-activate com.apple.Terminal -title #win (in 3s)"
   assert "$(get-stdin)" same_as "notification text"
 }
 
@@ -29,7 +29,7 @@
 
   run zsh-notify success 3  <<<"notification text"
   assert $state equals 0
-  assert "$(get-args)" same_as "-activate com.apple.terminal -contentImage custom.gif -title #win (in 3s)"
+  assert "$(get-args)" same_as "-activate com.apple.Terminal -contentImage custom.gif -title #win (in 3s)"
   assert "$(get-stdin)" same_as "notification text"
 }
 
@@ -64,6 +64,46 @@
   run get-args
   assert $state equals 0
   assert "$output" same_as "-activate com.googlecode.iterm2 -contentImage custom.gif -title #win (in 3s)"
+
+  run get-stdin
+  assert $state equals 0
+  assert "$output" same_as "notification text"
+}
+
+@test 'zsh-notify - terminal-notifier in any other macOS terminal' {
+  if ! command -v osascript 1>/dev/null 2>/dev/null || [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] \
+    || [[ "$TERM_PROGRAM" == "iTerm.app" ]] || [[ -n "$ITERM_SESSION_ID" ]];
+  then
+    skip 'must be run in macOS terminal that is not iTerm2 or Apple Terminal (e.g. Alacritty)'
+  fi
+
+  run zsh-notify success 3  <<<"notification text"
+  assert $state equals 0
+
+  run get-args
+  assert $state equals 0
+  assert "$output" matches "-activate [^\\s]* -title \#win \\(in 3s\\)"
+
+  run get-stdin
+  assert $state equals 0
+  assert "$output" same_as "notification text"
+}
+
+@test 'zsh-notify - terminal-notifier in any other macOS terminal with icon' {
+  if ! command -v osascript 1>/dev/null 2>/dev/null || [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] \
+    || [[ "$TERM_PROGRAM" == "iTerm.app" ]] || [[ -n "$ITERM_SESSION_ID" ]];
+  then
+    skip 'must be run in macOS terminal that is not iTerm2 or Apple Terminal (e.g. Alacritty)'
+  fi
+
+  zstyle ':notify:*' success-icon custom.gif
+
+  run zsh-notify success 3  <<<"notification text"
+  assert $state equals 0
+
+  run get-args
+  assert $state equals 0
+  assert "$output" matches "-activate [^\\s]* -contentImage custom.gif -title #win \\(in 3s\\)"
 
   run get-stdin
   assert $state equals 0


### PR DESCRIPTION
After this change, the plugin will determine the app ID by the PID of the top-level parent process (which corresponds to the currently used terminal emulator) when using any terminal besides iTerm or Apple Terminal. This enables basic plugin functionality, such as determining if the terminal emulator is in focus, sending notifications, and navigating the user back to the terminal after they press "Show" button inside notification.