### PR TITLE
Add vscode to supported TERM_PROGRAM checks 

### DIFF
--- a/applescript/functions
+++ b/applescript/functions
@@ -30,6 +30,10 @@ function is-terminal-active() {
             term=iterm2
         elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$TERM_SESSION_ID" ]]; then
             term=apple-terminal
+        elif [[ "$TERM_PROGRAM" == 'vscode' ]]; then
+            # integrated VS Code terminal doesn't expose window state via AppleScript;
+            # assume active so notifications proceed in the integrated terminal.
+            return 0
         else
             return 2
         fi
@@ -76,6 +80,9 @@ function zsh-notify() {
         app_id="com.googlecode.iterm2"
     elif [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$TERM_SESSION_ID" ]]; then
         app_id="com.apple.terminal"
+    elif [[ "$TERM_PROGRAM" == 'vscode' ]]; then
+        # no app id for VS Code integrated terminal; leave app_id empty
+        app_id=""
     fi
 
     if [[ -n "$app_id" ]]; then
@@ -94,6 +101,8 @@ function zsh-notify() {
         -title "${title}" <<< "$message" > /dev/null 2>&1 &!
 
     if zstyle -t ':notify:' activate-terminal; then
-        osascript <<< "tell app id \"$app_id\" to activate" 1>/dev/null
+        if [[ -n "$app_id" ]]; then
+            osascript <<< "tell app id \"$app_id\" to activate" 1>/dev/null
+        fi
     fi
 }

--- a/notify.plugin.zsh
+++ b/notify.plugin.zsh
@@ -2,7 +2,7 @@
 
 plugin_dir="$(dirname $0:A)"
 
-if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ -n "$ITERM_SESSION_ID" ]] || [[ -n "$TERM_SESSION_ID" ]]; then
+if [[ "$TERM_PROGRAM" == 'iTerm.app' ]] || [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] || [[ "$TERM_PROGRAM" == 'vscode' ]] || [[ -n "$ITERM_SESSION_ID" ]] || [[ -n "$TERM_SESSION_ID" ]]; then
     source "$plugin_dir"/applescript/functions
 elif [[ "$DISPLAY" != '' ]] && command -v xdotool > /dev/null 2>&1 &&  command -v wmctrl > /dev/null 2>&1; then
     source "$plugin_dir"/xdotool/functions
@@ -108,7 +108,7 @@ function zsh-notify-after-command() {
         if _zsh-notify-should-notify "$last_status" "$time_elapsed"; then
             local result
             result="$(((last_status == 0)) && echo success || echo error)"
-            "$notifier" "$result" "$time_elapsed" <<< "$zsh_notify_last_command"
+            "${notifier}" "$result" "$time_elapsed" <<< "$zsh_notify_last_command"
         fi
     )  2>&1 | sed 's/^/zsh-notify: /' >> "$error_log"
 


### PR DESCRIPTION
Added `vscode` to supported TERM_PROGRAM and treating integrated VS Code terminal as active for applescript checks.